### PR TITLE
Changes to not open things up for xss attacks

### DIFF
--- a/flexx/app/_asset.py
+++ b/flexx/app/_asset.py
@@ -306,5 +306,5 @@ class Bundle(Asset):
         if len(self.assets + self.modules) > 1:
             source.insert(0, '/* Bundle contents:\n' + '\n'.join(toc) + '\n*/\n')
         #if isjs:
-        #    source.append('window.flexx.spin("%s");' % ('*' * len(self.modules)))
+        #    source.append('window.flexx.spin(%i);' % len(self.modules))
         return '\n\n'.join(source)

--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -72,15 +72,15 @@ class Flexx:
         for session in self.sessions.values():
             session.exit()
     
-    def spin(self, text='*'):
+    def spin(self, n=1):
         RawJS("""
         if (!window.document.body) {return;}
         var el = window.document.body.children[0];
         if (el && el.classList.contains("flx-spinner")) {
-            if (text === null) {
+            if (n === null) {
                 el.style.display = 'none';  // Stop the spinner
             } else {
-                el.children[0].innerHTML += text.replace(/\*/g, '&#9632');
+                el.children[0].innerHTML += '&#9632'.repeat(n);
             }
         }
         """)
@@ -254,7 +254,7 @@ class JsSession:
         # Check WebSocket support
         WebSocket = window.WebSocket
         if (WebSocket is undefined):
-            window.document.body.innerHTML = 'Browser does not support WebSockets'
+            window.document.body.textContent = 'Browser does not support WebSockets'
             raise "FAIL: need websocket"
         
         # Construct ws url
@@ -294,7 +294,7 @@ class JsSession:
                 msg += ': %s (%i)' % (evt.reason, evt.code)
             if not window.flexx.is_notebook:
                 # todo: show modal or cooky-like dialog instead of killing whole page
-                window.document.body.innerHTML = msg
+                window.document.body.textContent = msg
             else:
                 window.console.info(msg)
         def on_ws_error(self, evt):

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -348,8 +348,7 @@ class Widget(app.JsComponent):
         if vnode and vnode.nodeName:  # is DOM node
             return vnode
         elif isinstance(vnode, str):
-            # vnode = {'type': 'span', 'props': {}, 'children': vnode}
-            return window.document.createTextNode(vnode)  #  not in node.children
+            return window.document.createTextNode(vnode)
         elif not isinstance(vnode, dict):
             raise TypeError('Widget._render_dom() needs virtual nodes '
                             'to be dicts, not ' + vnode)

--- a/flexx/ui/examples/boxes.py
+++ b/flexx/ui/examples/boxes.py
@@ -21,7 +21,7 @@ class Boxes(ui.Widget):
             
             with ui.VBox(flex=1):
                 
-                ui.Label(text='<b>Box mode</b> (aware of natural size)')
+                ui.Label(html='<b>Box mode</b> (aware of natural size)')
                 ui.Label(text='flex: 1, sub-flexes: 0, 0, 0')
                 with ui.HBox(flex=1):
                     Panel(text='A', flex=0)
@@ -45,7 +45,7 @@ class Boxes(ui.Widget):
             
             with ui.VBox(flex=1):
                 
-                ui.Label(text='<b>Fix mode</b> (high level layout)')
+                ui.Label(html='<b>Fix mode</b> (high level layout)')
                 ui.Label(text='flex: 1, sub-flexes: 0, 0, 0')
                 with ui.HFix(flex=1):
                     Panel(text='A', flex=0)

--- a/flexx/ui/examples/hv_layout.py
+++ b/flexx/ui/examples/hv_layout.py
@@ -59,7 +59,7 @@ class MyWidget(ui.Label):
         text = self._base_text + '<br>\n'
         text += 'widget with flex (%s) ' % self.flex
         text += 'in %s %s layout.' % (self.parent.orientation, self.parent.mode)
-        self.set_text(text)
+        self.set_html(text)
 
 
 class MyLayout(ui.HVLayout):

--- a/flexx/ui/examples/monitor.py
+++ b/flexx/ui/examples/monitor.py
@@ -55,7 +55,7 @@ class Monitor(app.PyComponent):
     def init(self):
         
         with ui.VBox():
-            ui.Label(text='<h3>Server monitor</h3>')
+            ui.Label(html='<h3>Server monitor</h3>')
             if app.current_server().serving[0] == 'localhost':
                 # Don't do this for a public server
                 self.button = ui.Button(text='Do some work')
@@ -97,7 +97,7 @@ class MonitorView(ui.VBox):
         
         # Set connections
         n = info.sessions, info.total_sessions
-        self.status.set_text('There are %i connected clients.<br />' % n[0] +
+        self.status.set_html('There are %i connected clients.<br />' % n[0] +
                              'And in total we served %i connections.<br />' % n[1])
         
         # Prepare plots

--- a/flexx/ui/examples/send_data.py
+++ b/flexx/ui/examples/send_data.py
@@ -79,7 +79,7 @@ class SendDataView(ui.Widget):
         # Show the data as text. We could also e.g. plot it.
         text = ['%i: %f<br />' % (i, data[i]) for i in range(len(data))]
         header = 'This data (%i elements) was send in binary form:<br />' % len(data)
-        self.label.set_text(header + ''.join(text))
+        self.label.set_html(header + ''.join(text))
 
 
 if __name__ == '__main__':

--- a/flexx/ui/examples/serve_data.py
+++ b/flexx/ui/examples/serve_data.py
@@ -67,7 +67,7 @@ class View(ui.Label):
         html += '<p>This is session "%s"</p>' % self.session.id
         html += '<img src="%s" />' % link1
         html += '<img src="%s" />' % link2
-        self.set_text(html)
+        self.set_html(html)
 
 
 if __name__ == '__main__':

--- a/flexx/ui/examples/store.py
+++ b/flexx/ui/examples/store.py
@@ -36,7 +36,7 @@ class MyPersonLabel(ui.Widget):
     """
     
     def _render_dom(self):
-        return self.root.first_name + ' ' + self.root.last_name
+        return [self.root.first_name + ' ' + self.root.last_name]
 
 
 class View(ui.Widget):

--- a/flexx/ui/examples/twente.py
+++ b/flexx/ui/examples/twente.py
@@ -130,9 +130,9 @@ class Twente(ui.Widget):
                 ui.Widget(flex=3)
             with ui.VBox(flex=4):
                 self.plot = ui.PlotWidget(flex=1,
-                                            xdata=years, yrange=(-5, 20),
-                                            title='Average monthly temperature',
-                                            xlabel='year', ylabel=u'temperature (°C)')
+                                          xdata=years, yrange=(-5, 20),
+                                          title='Average monthly temperature',
+                                          xlabel='year', ylabel=u'temperature (°C)')
             ui.Widget(flex=1)
 
     @event.reaction

--- a/flexx/ui/examples/using_python_in_js.py
+++ b/flexx/ui/examples/using_python_in_js.py
@@ -57,7 +57,7 @@ class UsingPython(ui.Widget):
         lines.append('String with escaped html: ' + escape('html <tags>!'))
         lines.append('String with escaped html: ' + escape('Woezel & Pip'))
         
-        self.label = ui.Label(wrap=0, text='<br />'.join(lines))
+        self.label = ui.Label(wrap=0, html='<br />'.join(lines))
 
 
 if __name__ == '__main__':

--- a/flexx/ui/layouts/_tabs.py
+++ b/flexx/ui/layouts/_tabs.py
@@ -123,7 +123,7 @@ class TabLayout(StackLayout):
         for i in range(len(children)):
             widget = children[i]
             node = self._tabbar.children[i]
-            node.innerHTML = widget.title
+            node.textContent = widget.title
             if widget is current:
                 node.classList.add('flx-current')
             else:

--- a/flexx/ui/widgets/_bokeh.py
+++ b/flexx/ui/widgets/_bokeh.py
@@ -109,7 +109,7 @@ class BokehWidget(Widget):
         """ Set the plot using its script/html components.
         """
         # Embed div
-        self.node.innerHTML = d.div
+        self.node.innerHTML = d.div  # We put trust in d.div
         # "exec" code
         el = window.document.createElement('script')
         el.innerHTML = d.script 

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -56,7 +56,7 @@ Example with interaction:
 """
 
 from ... import event
-from . import Widget
+from .._widget import Widget, create_element
 
 
 class BaseButton(Widget):
@@ -109,10 +109,9 @@ class Button(BaseButton):
         self._addEventListener(node, 'click', self.mouse_click, 0)
         return node
 
-    @event.reaction('text')
-    def __text_changed(self, *events):
-        self.node.innerHTML = events[-1].new_value
-
+    def _render_dom(self):
+        return [self.text]
+    
     @event.reaction('disabled')
     def __disabled_changed(self, *events):
         if events[-1].new_value:
@@ -138,10 +137,9 @@ class ToggleButton(BaseButton):
         self._addEventListener(node, 'click', self.mouse_click, 0)
         return node
     
-    @event.reaction('text')
-    def __text_changed(self, *events):
-        self.node.innerHTML = events[-1].new_value
-
+    def _render_dom(self):
+        return [self.text]
+    
     @event.reaction('mouse_click')
     def __toggle_checked(self, *events):
         self.set_checked(not self.checked)
@@ -165,18 +163,16 @@ class RadioButton(BaseButton):
         outernode = window.document.createElement('div')
         outernode.innerHTML = template.replace('ID', self.id)
         node = outernode.childNodes[0]
-        self.text_node = outernode.childNodes[1]
         self._addEventListener(node, 'click', self._check_radio_click, 0)
         return outernode, node
+    
+    def _render_dom(self):
+        return [self.node, create_element('label', {}, self.text)]
     
     @event.reaction('parent')
     def __update_group(self, *events):
         if self.parent:
             self.node.name = self.parent.id
-
-    @event.reaction('text')
-    def __text_changed(self, *events):
-        self.text_node.innerHTML = events[-1].new_value
 
     @event.reaction('checked')
     def __check_changed(self, *events):
@@ -209,16 +205,13 @@ class CheckBox(BaseButton):
         outernode = window.document.createElement('div')
         outernode.innerHTML = template.replace('ID', self.id)
         node = outernode.childNodes[0]
-        self.text_node = outernode.childNodes[1]
-
         self._addEventListener(node, 'click', self.mouse_click, 0)
         self._addEventListener(node, 'change', self._check_changed_from_dom, 0)
         return outernode, node
     
-    @event.reaction('text')
-    def __text_changed(self, *events):
-        self.text_node.innerHTML = events[-1].new_value
-
+    def _render_dom(self):
+        return [self.node, create_element('label', {}, self.text)]
+    
     @event.reaction('checked')
     def __check_changed(self, *events):
         self.node.checked = self.checked

--- a/flexx/ui/widgets/_dropdown.py
+++ b/flexx/ui/widgets/_dropdown.py
@@ -122,11 +122,10 @@ class BaseDropdown(Widget):
         # <span class='flx-dd-button'></span>
         # <div class='flx-dd-strud'>&nbsp;</div>
         f2 = lambda e: self._submit_text() if e.which == 13 else None
-        
         return [create_element('span', 
                                {'className': 'flx-dd-label',
                                 'onclick': self._but_click},
-                               self.text + '&nbsp;'),
+                               self.text + '\u00A0'),
                 create_element('input',
                                {'className': 'flx-dd-edit',
                                 'onkeypress': f2,
@@ -135,7 +134,7 @@ class BaseDropdown(Widget):
                 create_element('span'),
                 create_element('span', {'className': 'flx-dd-button',
                                         'onclick': self._but_click}),
-                create_element('div', {'className': 'flx-dd-strud'}, '&nbsp;'),
+                create_element('div', {'className': 'flx-dd-strud'}, '\u00A0'),
                 ]
     
     def _but_click(self):
@@ -302,14 +301,16 @@ class ComboBox(BaseDropdown):
         # Create a virtual node for each option
         options = self.options
         option_nodes = []
-        strud = ''
+        strud = []
         for i in range(len(options)):
             key, text = options[i]
             clsname = 'highlighted-true' if self._highlighted == i else ''
             li = create_element('li',
                                 dict(index=i, className=clsname),
-                                text if len(text.strip()) else '&nbsp;')
-            strud += text + '&nbsp;&nbsp;<span class="flx-dd-space"></span><br />'
+                                text if len(text.strip()) else '\u00A0')
+            strud += [text + '\u00A0',
+                      create_element('span', {'class': "flx-dd-space"}),
+                      create_element('br')]
             option_nodes.append(li)
         
         # Update the list of nodes created by superclass

--- a/flexx/ui/widgets/_group.py
+++ b/flexx/ui/widgets/_group.py
@@ -57,4 +57,4 @@ class GroupWidget(Widget):
     
     @event.reaction('title')
     def _title_changed(self, *events):
-        self._legend.innerHTML = self.title
+        self._legend.textContent = self.title

--- a/flexx/ui/widgets/_label.py
+++ b/flexx/ui/widgets/_label.py
@@ -33,8 +33,15 @@ class Label(Widget):
             -ms-user-select: text;
         }"""
     
-    text = event.StringProp('', settable=True, doc="""
-        The text/html on the label.
+    text = event.StringProp('', doc="""
+        The text shown in the label (HTML is shown verbatim).
+        """)
+    
+    html = event.StringProp('', doc="""
+        The html shown in the label.
+        
+        Warning: there is a risk of introducing openings for XSS attacks
+        when html is introduced that you do not control (e.g. from user input).
         """)
     
     wrap = event.IntProp(0, settable=True, doc="""
@@ -42,11 +49,28 @@ class Label(Widget):
         lines. Set to 0/False for no wrap (default), 1/True for word-wrap,
         2 for character wrap.
         """)
-
-    @event.reaction('text')
-    def _text_changed(self, *events):
-        self.node.innerHTML = self.text
-        self.check_real_size(True)
+    
+    def init(self):
+        if self.text:
+            self.set_text(self.text)
+        elif self.html:
+            self.set_html(self.html)
+    
+    @event.action
+    def set_text(self, text):
+        """ Setter for the text property.
+        """
+        self.node.textContent = text
+        self._mutate_text(self.node.textContent)
+        self._mutate_html(self.node.innerHTML)
+    
+    @event.action
+    def set_html(self, html):
+        """ Setter for the html property. Use with care.
+        """
+        self.node.innerHTML = html
+        self._mutate_text(self.node.textContent)
+        self._mutate_html(self.node.innerHTML)
     
     @event.reaction('wrap')
     def _wrap_changed(self, *events):

--- a/flexx/ui/widgets/_media.py
+++ b/flexx/ui/widgets/_media.py
@@ -77,7 +77,7 @@ class VideoWidget(Widget):
     def _create_dom(self):
         node = window.document.createElement('video')
         node.controls = 'controls'
-        node.innerHTML = 'Your browser does not support HTML5 video.'
+        node.textContent = 'Your browser does not support HTML5 video.'
         
         self.src_node = window.document.createElement('source')
         self.src_node.type = 'video/mp4'

--- a/flexx/webruntime/_common.py
+++ b/flexx/webruntime/_common.py
@@ -44,6 +44,7 @@ import os.path as op
 import os
 import sys
 import time
+import signal
 import atexit
 import shutil
 import threading
@@ -86,7 +87,13 @@ class BaseRuntime:
         self._leftover_kwargs = kwargs
         
         assert self.get_name()
+        
+        # Close the runtime when Python closes cleanly
         atexit.register(self.close)
+        
+        # Increase chance of closing runtime when Python is forced to stop
+        signal.signal(signal.SIGTERM, self.close)
+        signal.signal(signal.SIGINT, self.close)
         
         self._exe = None
         self._version = None


### PR DESCRIPTION
Closes #293 

This makes it harder to insert raw html in your app. There are still two places where this is possible: the `Label.html` property, where we put a warning in the docs, and via `_render_dom` by providing an `innerHTML` prop, in which case the user probably knows what she is doing, and we warn for it in the docs.

We make use of  `textContent` instead of  `innerHTML` in several places. The `Label` class now has a text and html property, setting either updates both (let the browser do the work, because one can set `textContent` and get `innerHTML` and vice versa).

Also snuck in a tweak to increase the chance of closing the webruntime when Python is killed.