### PR TITLE
New emitters for input widgets to better distinguish user input

### DIFF
--- a/flexx/ui/layouts/_hv.py
+++ b/flexx/ui/layouts/_hv.py
@@ -367,6 +367,24 @@ class HVLayout(Layout):
         
         self._mutate_splitter_positions(positions2)
     
+    @event.emitter
+    def user_splitter_positions(self, *positions):
+        """ Event emitted when the splitter is positioned by the user.
+        The event has a ``positions`` attribute.
+        """
+        if self.mode != 'SPLIT':
+            return None  # do not emit
+        
+        positions2 = []
+        for i in range(len(positions)):
+            pos = positions[i]
+            if pos is not None:
+                pos = max(0.0, min(1.0, float(pos)))
+            positions2.append(pos)
+            
+        self.set_splitter_positions(*positions)
+        return {'positions': positions}
+    
     ## General reactions and hooks
     
     @event.reaction('orientation', 'spacing', 'padding')
@@ -656,7 +674,7 @@ class HVLayout(Layout):
         
         # Set (relative) splitter positions. This may seem like a detour, but
         # this way the splits will scale nicely e.g. during resizing.
-        self.set_splitter_positions(*[pos/available_size for pos in abs_positions])
+        self.user_splitter_positions(*[pos/available_size for pos in abs_positions])
     
     def __apply_positions(self):
         """ Set sep.abs_pos and sep.rel_pos on each separator.

--- a/flexx/ui/layouts/_tabs.py
+++ b/flexx/ui/layouts/_tabs.py
@@ -131,7 +131,19 @@ class TabLayout(StackLayout):
         for i in range(len(nodes)):
             nodes[i].style.width = width + 'px'
     
+    @event.emitter
+    def user_current(self, current):
+        """ Event emitted when the user selects a tab. Can be used to distinguish
+        user-invoked from programatically-invoked tab changes.
+        Has ``old_value`` and ``new_value`` attributes.
+        """
+        if isinstance(current, (float, int)):
+            current = self.children[int(current)]
+        d = {'old_value': self.current, 'new_value': current}
+        self.set_current(current)
+        return d
+    
     def _tabbar_click(self, e):
         index = e.target.index
         if index >= 0:
-            self.set_current(index)
+            self.user_current(index)

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -76,9 +76,11 @@ class BaseButton(Widget):
     text = event.StringProp('', settable=True, doc="""
         The text on the button.
         """)
+    
     checked = event.BoolProp(False, settable=True, doc="""
         Whether the button is checked.
         """)
+    
     disabled = event.BoolProp(False, settable=True, doc="""
         Whether the button is disabled.
         """)
@@ -91,6 +93,15 @@ class BaseButton(Widget):
         """
         e.target.blur()
         return self._create_mouse_event(e)
+    
+    @event.emitter
+    def user_checked(self, checked):
+        """ Event emitted when the user (un)checks this button. Has
+        ``old_value`` and ``new_value`` attributes.
+        """
+        d = {'old_value': self.checked, 'new_value': checked}
+        self.set_checked(checked)
+        return d
 
 
 class Button(BaseButton):
@@ -132,7 +143,7 @@ class ToggleButton(BaseButton):
     
     @event.reaction('mouse_click')
     def __toggle_checked(self, *events):
-        self.set_checked(not self.checked)
+        self.user_checked(not self.checked)
 
     @event.reaction('checked')
     def __check_changed(self, *events):
@@ -184,7 +195,7 @@ class RadioButton(BaseButton):
                 if isinstance(child, RadioButton) and child is not self:
                     child.set_checked(child.node.checked)
         # Turn on this button (last)
-        self.set_checked(self.node.checked)
+        self.user_checked(self.node.checked)  # instead of set_checked
         # Process actual click event
         self.mouse_click(ev)
 
@@ -214,4 +225,4 @@ class CheckBox(BaseButton):
         self.node.checked = self.checked
 
     def _check_changed_from_dom(self, ev):
-        self.set_checked(self.node.checked)
+        self.user_checked(self.node.checked)

--- a/flexx/ui/widgets/_color.py
+++ b/flexx/ui/widgets/_color.py
@@ -40,12 +40,21 @@ class ColorSelectWidget(Widget):
         self._addEventListener(node, 'input', self._color_changed_from_dom, 0)
         return node
     
+    @event.emitter
+    def user_color(self, color):
+        """ Event emitted when the user changes the color. Has ``old_value``
+        and ``new_value`` attributes.
+        """
+        d = {'old_value': self.color, 'new_value': color}
+        self.set_color(color)
+        return d
+    
     @event.reaction('color')
     def _color_changed(self, *events):
         self.node.value = self.color.hex  # hex is html-compatible, color.css is not
     
     def _color_changed_from_dom(self, e):
-        self.set_color(self.node.value)
+        self.user_color(self.node.value)
 
     @event.reaction('disabled')
     def __disabled_changed(self, *events):

--- a/flexx/ui/widgets/_dropdown.py
+++ b/flexx/ui/widgets/_dropdown.py
@@ -205,8 +205,10 @@ class ComboBox(BaseDropdown):
     with an editable text. It can be used to select among a set of
     options in a more compact manner than a TreeWidget would.
     Optionally, the text of the combobox can be edited.
-    React to the ``text`` and/or ``selected_index`` properties to keep
-    track of interactions.
+    
+    It is generally good practive to react to ``user_selected`` to detect user
+    interaction, and react to ``text``, ``selected_key`` or ``selected_index``
+    to keep track of all kinds of (incl. programatic) interaction .
     
     When the combobox is expanded, the arrow keys can be used to select
     an item, and it can be made current by pressing Enter or spacebar.
@@ -291,6 +293,19 @@ class ComboBox(BaseDropdown):
         # and this works too.
         self.set_options(self.options)
     
+    @event.emitter
+    def user_selected(self, index):
+        """ Event emitted when the user selects an item using the mouse or
+        keyboard. The event has attributes ``index``, ``key`` and ``text``.
+        """
+        options = self.options
+        if index >= 0 and index < len(options):
+            key, text = options[index]
+            self.set_selected_index(index)
+            self.set_selected_key(key)
+            self.set_text(text)
+            return dict(index=index, key=key, text=text)
+    
     @event.action
     def set_options(self, options):
         # If dict ...
@@ -369,11 +384,7 @@ class ComboBox(BaseDropdown):
         self._select_from_ul(e.target.index)
     
     def _select_from_ul(self, index):
-        if index >= 0:
-            key, text = self.options[index]
-            self.set_selected_index(index)
-            self.set_selected_key(key)
-            self.set_text(text)
+        self.user_selected(index)
         self._collapse()
     
     def _key_down(self, e):

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -107,6 +107,23 @@ class Slider(Widget):
     def init(self):
         self._dragging = None
     
+    @event.emitter
+    def user_value(self, value):
+        """ Event emitted when the user manipulates the slider.
+        Has ``old_value`` and ``new_value`` attributes.
+        """
+        d = {'old_value': self.value, 'new_value': value}
+        self.set_value(value)
+        return d
+    
+    @event.emitter
+    def user_done(self):
+        """ Event emitted when the user stops manipulating the slider. Has
+        ``old_value`` and ``new_value`` attributes (which have the same value).
+        """
+        d = {'old_value': self.value, 'new_value': self.value}
+        return d
+    
     @event.action
     def set_value(self, value):
         global Math
@@ -161,6 +178,7 @@ class Slider(Widget):
             self.outernode.blur()
         self._dragging = None
         self.outernode.classList.remove('flx-dragging')
+        self.user_done()
         return super().mouse_down(e)
     
     @event.emitter
@@ -172,7 +190,7 @@ class Slider(Widget):
             x2 = e.clientX
             mi, ma = self.min, self.max
             value_diff = (x2 - x1) / self.outernode.clientWidth * (ma - mi)
-            self.set_value(ref_value + value_diff)
+            self.user_value(ref_value + value_diff)
         else:
             return super().mouse_move(e)
     
@@ -181,7 +199,8 @@ class Slider(Widget):
         for ev in events:
             if ev.key == 'Escape':
                 self.outernode.blur()
+                self.user_done()
             elif ev.key == 'ArrowRight':
-                self.set_value(self.value + self.step)
+                self.user_value(self.value + self.step)
             elif ev.key == 'ArrowLeft':
-                self.set_value(self.value - self.step)
+                self.user_value(self.value - self.step)

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -489,7 +489,7 @@ class TreeItem(Widget):
     
     @event.emitter
     def user_selected(self, selected):
-        """ Event emitted when the user selects this item. Has ``old_value``
+        """ Event emitted when the user (un)selects this item. Has ``old_value``
         and ``new_value`` attributes. One can call this emitter directly to
         emulate a user-selection, but note that this bypasses the max_selected
         policy.
@@ -500,7 +500,7 @@ class TreeItem(Widget):
     
     @event.emitter
     def user_checked(self, checked):
-        """ Event emitted when the user checks this item. Has ``old_value``
+        """ Event emitted when the user (un)checks this item. Has ``old_value``
         and ``new_value`` attributes.
         """
         d = {'old_value': self.checked, 'new_value': checked}
@@ -509,7 +509,7 @@ class TreeItem(Widget):
     
     @event.emitter
     def user_collapsed(self, collapsed):
-        """ Event emitted when the user collapses this item. Has ``old_value``
+        """ Event emitted when the user (un)collapses this item. Has ``old_value``
         and ``new_value`` attributes.
         """
         d = {'old_value': self.collapsed, 'new_value': collapsed}

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -272,7 +272,7 @@ class TreeWidget(Widget):
                 modifiers = ev.modifiers if ev.modifiers else []
                 if 'Shift' in modifiers:  # Ctrl can also be in modifiers
                     # Select everything between last selected and current
-                    if self._last_selected and self._last_selected.selected:
+                    if self._last_selected is not None:
                         if self._last_selected is not item:
                             mark_selected = False
                             for i in self.get_all_items():
@@ -287,17 +287,17 @@ class TreeWidget(Widget):
                     self._last_selected = item
                 elif 'Ctrl' in modifiers:
                     # Toggle
-                    item.user_selected(not item.selected)
-                    if item.selected:
-                        self._last_selected = item
+                    select = not item.selected
+                    item.user_selected(select)
+                    self._last_selected = item if select else None
                 else:
                     # Similar as when max_selected is 1
                     for i in self.get_all_items():
                         if i.selected and i is not item:
                             i.user_selected(False)
-                    item.user_selected(not item.selected)
-                    if item.selected:
-                        self._last_selected = item
+                    select = not item.selected
+                    item.user_selected(select)
+                    self._last_selected = item if select else None
         
         elif self.max_selected == 1:
             # Selecting one, deselects others

--- a/flexxamples/testers/tricky_events.py
+++ b/flexxamples/testers/tricky_events.py
@@ -53,6 +53,9 @@ class SyncedSlidersRight(SyncedSlidersBase):
     which avoids a ping-pong effect. Only having a single (normal) reaction
     reduced the chance of a ping-pong effect, but does not elliminate it.
     
+    Even better would be to react to ``user_value``  or ``user_done``
+    to avoid ping-ping altogether.
+    
     A nice addition would be to add an action that sets both slider
     values at the same time.
     """


### PR DESCRIPTION
It's not uncommon for an input widget to be used to update a certain value of an item, but also to set the widget once another item becomes "active". This can cause annoying behavior which can usually be dealt with, but not without jumping through a hoop or two.

This PR adds emitters that can be reacted to, that emit specifically for user interaction (i.e. not programmatic updates). I think I've got all input widget, and even two layout widgets.