### PR TITLE
Tweaks to layout and CSS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE README.md
+recursive-include docs *
+prune docs/_build
+prune docs/ext/__pycache__
+
+global-exclude .git*
+global-exclude *.pyo
+global-exclude *.pyc

--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -132,7 +132,7 @@ class Flexx:
         self.sessions[session_id] = s
     
     def _handle_error(self, evt):
-        msg = short = evt.message
+        msg = short_msg = evt.message
         if not window.evt:
             window.evt = evt
         if evt.error and evt.error.stack:  # evt.error can be None for syntax err
@@ -164,7 +164,7 @@ class Flexx:
         evt.preventDefault()  # Don't do the standard error 
         window.console.ori_error(msg)
         for session in self.sessions.values():
-            session.send_command("ERROR", short)
+            session.send_command("ERROR", short_msg)
 
 class JsSession:
     

--- a/flexx/ui/layouts/_form.py
+++ b/flexx/ui/layouts/_form.py
@@ -219,7 +219,7 @@ class FormLayout(BaseTableLayout):
         # Collect contributions of child widgets
         mima1 = [0, 1e9, 0, 0]
         for child in self.children:
-            mima2 = child.size_min_max
+            mima2 = child._size_limits
             mima1[0] = max(mima1[0], mima2[0])
             mima1[1] = min(mima1[1], mima2[1])
             mima1[2] += mima2[2]

--- a/flexx/ui/layouts/_hv.py
+++ b/flexx/ui/layouts/_hv.py
@@ -536,9 +536,12 @@ class HVLayout(Layout):
                 child.check_real_size()
         else:
             # Enfore a rerender by mutating splitter_positions
-            sp = self.splitter_positions
-            self._mutate_splitter_positions(())
-            self._mutate_splitter_positions(sp)
+            sp1 = ()
+            sp2 = self.splitter_positions
+            if len(sp2) == 0:
+                sp1 = (1, )
+            self._mutate_splitter_positions(sp1)
+            self._mutate_splitter_positions(sp2)
     
     ## Reactions for box mode
     

--- a/flexx/ui/layouts/_tabs.py
+++ b/flexx/ui/layouts/_tabs.py
@@ -35,6 +35,8 @@ class TabLayout(StackLayout):
     
     .flx-TabLayout > .flx-Widget {
         top: 30px;
+        margin: 0;
+        height: calc(100% - 30px);
         border: 1px solid #ddd;
     }
     
@@ -67,6 +69,9 @@ class TabLayout(StackLayout):
         border-radius: 3px 3px 0px 0px;
         margin-left: -1px;
         transition: background 0.3s;
+    }
+    .flx-tabbar > .flx-tab-item:first-of-type {
+        margin-left: 0;
     }
     
     .flx-tabbar > .flx-tab-item.flx-current {

--- a/flexx/ui/widgets/_bokeh.py
+++ b/flexx/ui/widgets/_bokeh.py
@@ -88,6 +88,8 @@ class BokehWidget(Widget):
     instantiate the widget from Python.
     """
     
+    DEFAULT_MIN_SIZE = 100, 100
+    
     CSS = """
     .flx-BokehWidget > .plotdiv {
         overflow: hidden;

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -19,7 +19,7 @@ class BaseButton(Widget):
     """ Abstract button class.
     """
     
-    DEFAULT_MIN_SIZE = 10, 28
+    DEFAULT_MIN_SIZE = 10, 24
     
     CSS = """
 
@@ -101,6 +101,8 @@ class BaseButton(Widget):
 class Button(BaseButton):
     """ A push button.
     """
+    
+    DEFAULT_MIN_SIZE = 10, 28
 
     def _create_dom(self):
         global window
@@ -124,6 +126,8 @@ class ToggleButton(BaseButton):
     """ A button that can be toggled. It behaves like a checkbox, while
     looking more like a regular button.
     """
+    
+    DEFAULT_MIN_SIZE = 10, 28
     
     def _create_dom(self):
         global window

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -18,11 +18,12 @@ from .._widget import Widget
 class BaseButton(Widget):
     """ Abstract button class.
     """
-
+    
+    DEFAULT_MIN_SIZE = 10, 28
+    
     CSS = """
 
     .flx-BaseButton {
-        min-height: 16px;
         white-space: nowrap;
         padding: 0.2em 0.4em;
         border-radius: 3px;
@@ -69,8 +70,6 @@ class BaseButton(Widget):
     .flx-RadioButton:hover > input, .flx-CheckBox:hover > input {
         color: #036;
     }
-
-    
     """
 
     text = event.StringProp('', settable=True, doc="""

--- a/flexx/ui/widgets/_canvas.py
+++ b/flexx/ui/widgets/_canvas.py
@@ -51,10 +51,10 @@ class CanvasWidget(Widget):
     the ``init()`` method to get a contex to perform the actual drawing.
     """
     
+    DEFAULT_MIN_SIZE = 50, 50
+    
     CSS = """
     .flx-CanvasWidget {
-        min-width: 50px;
-        min-height: 50px;
         -webkit-user-select: none;
         -moz-user-select: none;
         -ms-user-select: none;

--- a/flexx/ui/widgets/_color.py
+++ b/flexx/ui/widgets/_color.py
@@ -25,6 +25,8 @@ class ColorSelectWidget(Widget):
     on Firefox and Chrome, but not on IE/Edge last time I checked.
     """
     
+    DEFAULT_MIN_SIZE = 28, 28
+    
     color = event.ColorProp('#000000', settable=True, doc="""
         The currently selected color.
         """)

--- a/flexx/ui/widgets/_dropdown.py
+++ b/flexx/ui/widgets/_dropdown.py
@@ -35,6 +35,8 @@ class BaseDropdown(Widget):
     """ Base class for drop-down-like widgets.
     """
     
+    DEFAULT_MIN_SIZE = 50, 28
+    
     CSS = """
         
         .flx-BaseDropdown {
@@ -44,8 +46,7 @@ class BaseDropdown(Widget):
             border-radius: 3px;
             padding: 2px;
             border: 1px solid #aaa;
-            min-height: 1.7em;
-            max-height: 1.7em;
+            max-height: 28px; /* overridden by maxsize */
             white-space: nowrap; /* keep label and but on-line */
             background: #e8e8e8
         }

--- a/flexx/ui/widgets/_group.py
+++ b/flexx/ui/widgets/_group.py
@@ -40,7 +40,7 @@ class GroupWidget(Widget):
     }
     .flx-GroupWidget > .flx-Layout {
         width: calc(100% - 10px);
-        height: calc(100% - 10px);
+        height: calc(100% - 25px);
     }
     
     """
@@ -57,6 +57,12 @@ class GroupWidget(Widget):
         for widget in self.children:
             nodes.append(widget.outernode)
         return nodes
+    
+    def _query_min_max_size(self):
+        w1, w2, h1, h2 = super()._query_min_max_size()
+        w1 += 10
+        h1 += 30
+        return w1, w2, h1, h2
     
     @event.reaction('title')
     def _title_changed(self, *events):

--- a/flexx/ui/widgets/_iframe.py
+++ b/flexx/ui/widgets/_iframe.py
@@ -20,6 +20,8 @@ class IFrame(Widget):
     a cross-source iframe.
     """
     
+    DEFAULT_MIN_SIZE = 10, 10
+    
     CSS = """
         .flx-IFrame {
             border: none;

--- a/flexx/ui/widgets/_label.py
+++ b/flexx/ui/widgets/_label.py
@@ -24,6 +24,8 @@ class Label(Widget):
     """ Widget to show text/html.
     """
     
+    DEFAULT_MIN_SIZE = 10, 24
+    
     CSS = """
         .flx-Label {
             border: 0px solid #454;

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -37,6 +37,8 @@ class LineEdit(Widget):
     """ An input widget to edit a line of text.
     """
     
+    DEFAULT_MIN_SIZE = 100, 28
+    
     CSS = """
     .flx-LineEdit {
         color: #333;

--- a/flexx/ui/widgets/_media.py
+++ b/flexx/ui/widgets/_media.py
@@ -26,6 +26,8 @@ class ImageWidget(Widget):
     """ Display an image from a url.
     """
     
+    DEFAULT_MIN_SIZE = 16, 16
+    
     _sequence = 0
     
     source = event.StringProp('', settable=True, doc="""
@@ -67,7 +69,9 @@ class ImageWidget(Widget):
 class VideoWidget(Widget):
     """ Display a video from a url.
     """
-
+    
+    DEFAULT_MIN_SIZE = 100, 100
+    
     source = event.StringProp('', settable=True, doc="""
         The source of the video. This must be a url of a resource
         on the web.
@@ -97,6 +101,8 @@ class VideoWidget(Widget):
 class YoutubeWidget(Widget):
     """ Display a Youtube video.
     """
+    
+    DEFAULT_MIN_SIZE = 100, 100
     
     source = event.StringProp('oHg5SJYRHA0', settable=True, doc="""
         The source of the video represented as the Youtube id.

--- a/flexx/ui/widgets/_plotwidget.py
+++ b/flexx/ui/widgets/_plotwidget.py
@@ -13,7 +13,7 @@ Simple example:
     
     p = ui.PlotWidget(xdata=range(5), ydata=[1,3,4,2,5], 
                       line_width=4, line_color='red', marker_color='',
-                      style='min-height:200px;')
+                      minsize=200)
 
 Also see examples: :ref:`sine.py`, :ref:`twente.py`, :ref:`monitor.py`.
 
@@ -30,7 +30,7 @@ class PlotWidget(CanvasWidget):
     plotting tasks.
     """
     
-    CSS = ".flx-PlotWidget {min-width: 300px; min-height: 200px;}"
+    DEFAULT_MIN_SIZE = 300, 200
     
     xdata = event.TupleProp((), doc="""
             A list of values for the x-axis. Set via the ``set_data()`` action.

--- a/flexx/ui/widgets/_progressbar.py
+++ b/flexx/ui/widgets/_progressbar.py
@@ -31,11 +31,11 @@ class ProgressBar(Widget):
     """ A widget to show progress.
     """
     
+    DEFAULT_MIN_SIZE = 40, 16
+    
     CSS = """
     
     .flx-ProgressBar {
-        min-height: 16px;
-        min-width: 40px;
         border: 1px solid #ddd;
         border-radius: 6px;
         background: #eee;

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -21,12 +21,10 @@ class Slider(Widget):
     range input).
     """
     
+    DEFAULT_MIN_SIZE = 40, 20
+    
     CSS = """
     
-    .flx-Slider {
-        min-height: 20px;
-        min-width: 40px;
-    }
     .flx-Slider:focus {
         outline: none;
     }

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -66,6 +66,8 @@ class TreeWidget(Widget):
     
     """
     
+    DEFAULT_MIN_SIZE = 100, 50
+    
     CSS = """
     
     /* ----- Tree Widget Mechanics ----- */

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -569,14 +569,14 @@ class TreeItem(Widget):
         title, text = self._render_title(), self._render_text()
         
         # Note that the outernode (the <li>) has not flx-Widget nor flx-TreeItem
-        extra_text_cls = ' hastitle' if len(title) > 0 else ''
+        text_class = 'text hastitle' if len(title) > 0 else 'text'
         return create_element('li', {'className': cnames},
                     create_element('span', {'className': 'flx-TreeItem ' + cnames},
                         create_element('span', {'className': 'padder'}),
                         create_element('span', {'className': 'collapsebut'}),
                         create_element('span', {'className': 'checkbut'}),
                         create_element('span', {'className': 'title'}, title),
-                        create_element('span', {'className': 'text' + extra_text_cls}, text),
+                        create_element('span', {'className': text_class}, text),
                         ),
                     create_element('ul', {}, subnodes),
                     )

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -186,7 +186,7 @@ class TreeWidget(Widget):
         content: '\\2610\\00a0';
     }
     
-    .flx-TreeWidget .flx-TreeItem > .text {
+    .flx-TreeWidget .flx-TreeItem > .text.hastitle {
         width: 50%;
     }
     /* ----- End Tree Widget ----- */
@@ -569,13 +569,14 @@ class TreeItem(Widget):
         title, text = self._render_title(), self._render_text()
         
         # Note that the outernode (the <li>) has not flx-Widget nor flx-TreeItem
+        extra_text_cls = ' hastitle' if len(title) > 0 else ''
         return create_element('li', {'className': cnames},
                     create_element('span', {'className': 'flx-TreeItem ' + cnames},
                         create_element('span', {'className': 'padder'}),
                         create_element('span', {'className': 'collapsebut'}),
                         create_element('span', {'className': 'checkbut'}),
                         create_element('span', {'className': 'title'}, title),
-                        create_element('span', {'className': 'text'}, text),
+                        create_element('span', {'className': 'text' + extra_text_cls}, text),
                         ),
                     create_element('ul', {}, subnodes),
                     )

--- a/flexxamples/demos/chatroom.py
+++ b/flexxamples/demos/chatroom.py
@@ -58,8 +58,8 @@ class ChatRoom(flx.PyComponent):
             flx.Widget(flex=1)
             with flx.VBox():
                 self.name_edit = flx.LineEdit(placeholder_text='your name')
-                self.people_label = flx.Label(flex=1, style='min-width: 250px')
-            with flx.VBox(style='min-width: 450px'):
+                self.people_label = flx.Label(flex=1, minsize=250)
+            with flx.VBox(minsize=450):
                 self.messages = MessageBox(flex=1)
                 with flx.HBox():
                     self.msg_edit = flx.LineEdit(flex=1,

--- a/flexxamples/demos/colab_painting.py
+++ b/flexxamples/demos/colab_painting.py
@@ -73,8 +73,6 @@ class ColabPaintingView(flx.Widget):
     .flx-ColabPaintingView .flx-CanvasWidget {
         background: #fff;
         border: 10px solid #000;
-        min-width: 400px; max-width: 400px;
-        min-height: 400px; max-height: 400px;
     }
     """
     
@@ -88,7 +86,7 @@ class ColabPaintingView(flx.Widget):
             flx.Widget(flex=1)
             with flx.HBox(flex=2):
                 flx.Widget(flex=1)
-                self.canvas = flx.CanvasWidget(flex=0)
+                self.canvas = flx.CanvasWidget(flex=0, minsize=400, maxsize=400)
                 flx.Widget(flex=1)
             flx.Widget(flex=1)
         

--- a/flexxamples/demos/splines.py
+++ b/flexxamples/demos/splines.py
@@ -292,16 +292,16 @@ class Splines(flx.Widget):
         
         with flx.HBox():
             
-            with flx.VBox(flex=0, style='min-width:150px'):
+            with flx.VBox(flex=0, minsize=150):
                 self.b1 = flx.RadioButton(text='Linear')
                 self.b2 = flx.RadioButton(text='Basis')
                 self.b3 = flx.RadioButton(text='Cardinal', checked=True)
                 self.b4 = flx.RadioButton(text='Catmull Rom')
                 self.b5 = flx.RadioButton(text='Lagrange')
                 self.b6 = flx.RadioButton(text='Lanczos')
-                flx.Widget(style='min-height:10px')
+                flx.Widget(minsize=10)
                 closed = flx.CheckBox(text='Closed')
-                flx.Widget(style='min-height:10px')
+                flx.Widget(minsize=10)
                 self.tension = flx.Slider(min=-0.5, max=1, value=0.5,
                                           text=lambda: 'Tension: {value}')
                 flx.Widget(flex=1)

--- a/flexxamples/demos/twente.py
+++ b/flexxamples/demos/twente.py
@@ -121,7 +121,7 @@ class Twente(flx.Widget):
         
         with flx.HFix():
             flx.Widget(flex=1)
-            with flx.VBox(flex=0, style='min-width:200px'):
+            with flx.VBox(flex=0, minsize=200):
                 with flx.GroupWidget(title='Plot options'):
                     flx.Label(text='Month')
                     self.month = flx.ComboBox(options=months, selected_index=12, style='width: 100%')

--- a/flexxamples/howtos/bokehdemo.py
+++ b/flexxamples/howtos/bokehdemo.py
@@ -31,7 +31,7 @@ class BokehExample(flx.PyComponent):
     
     def init(self):
         
-        with flx.HSplit(style='min-height:300px') as self.widget:
+        with flx.HSplit(minsize=300) as self.widget:
             self.plot1 = flx.BokehWidget.from_plot(p1, title='Scatter')
             with flx.VFix(title='Sine'):
                 Controls()

--- a/flexxamples/testers/minsize.py
+++ b/flexxamples/testers/minsize.py
@@ -1,0 +1,44 @@
+""" Test minsize property.
+"""
+
+from flexx import flx
+
+
+class Tester(flx.Widget):
+    
+    def init(self):
+        super().init()
+        
+        with flx.VBox():
+            
+            flx.Label(text='You should see 5 pairs of buttons')
+            
+            with flx.HFix():  # Use minsize in CSS of button widget
+                with flx.GroupWidget(title='asdas'):
+                    with flx.HFix():
+                        flx.Button(text='foo')
+                        flx.Button(text='bar')
+            
+            with flx.HFix(minsize=50):  # Set minsize prop on container
+                flx.Button(text='foo')
+                flx.Button(text='bar')
+            
+            with flx.HFix():  # Set minsize prop on widget
+                flx.Button(text='foo', minsize=50)
+                flx.Button(text='bar')
+                
+            with flx.HFix():  # Old school setting of style
+                flx.Button(text='foo', style='min-height:50px;')
+                flx.Button(text='bar', )
+            
+            with flx.Widget():  # Singleton widgets (e.g. custom classes)
+                with flx.HFix():
+                    flx.Button(text='foo')
+                    flx.Button(text='bar')
+            
+            flx.Widget(flex=1, style='background:#f99;')  # spacer
+
+
+if __name__ == '__main__':
+    m = flx.launch(Tester, 'firefox')
+    flx.run()


### PR DESCRIPTION
Closes #209

* tree items allow more space for text if there is no title
* Widget gets minsize and maxsize properties. These are the reference for minimum and maximum size, not the CSS!
* Though using `apply_style()` still works, because we can easily capture the setting of min-width and friends.
* The layouts are now much better able to communicate size limits upstream. This works around the flexbox bug that size limits is not properly taken into account for certain child configurations, plus we can communicate the limits over singleton widgets (common for custom classes that have a single layout child).
* Every widget that has some content has a proper default minimum size (set via a class property).
* E.g. group widgets now also work much better in different layouts.
* Fixes to TabLayout.