### PR TITLE
 Add Widget.minsize_from_children property 

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -670,6 +670,8 @@ class Widget(app.JsComponent):
         """
         # Get new limits
         w1, w2, h1, h2 = self._query_min_max_size()
+        w1 = max(0, w1)
+        h1 = max(0, h1)
         # Update the property, so that our parent may react
         self._set_size_limits((w1, w2, h1, h2))
         # Update the style, so that flexbox works

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -202,9 +202,9 @@ class Widget(app.JsComponent):
         """)
 
     size = event.FloatPairProp((0, 0), settable=False, doc="""
-        The actual size of the widget. Flexx tries to keep this value
-        up-to-date, but in e.g. a box layout, a change in a Button's
-        text can change the size of sibling widgets.
+        The actual size of the widget (readonly). Flexx tries to keep
+        this value up-to-date, but in e.g. a box layout, a change in a
+        Button's text can change the size of sibling widgets.
         """)
 
     minsize = event.FloatPairProp((0, 0), settable=True, doc="""
@@ -213,6 +213,19 @@ class Widget(app.JsComponent):
         Note that using "min-width" or "min-height" in ``apply_style()``.
         (and in the ``style`` kwarg) also set this property. Minimum sizes set
         in CSS are ignored.
+        """)
+
+    minsize_from_children = event.BoolProp(True, settable=True, doc="""
+        Whether the children are taken into account to calculate this
+        widget's size constraints. Default True: both the ``minsize``
+        of this widget and the size constraints of its children (plus
+        spacing and padding for layout widgets) are used to calculate
+        the size constraints for this widget.
+
+        Set to False to prevent the content in this widget to affect
+        the parent's layout, e.g. to allow fully collapsing this widget
+        when the parent is a splitter. If this widget has a lot of
+        content, you may want to combine with ``style='overflow-y: auto'``.
         """)
 
     maxsize = event.FloatPairProp((1e9, 1e9), settable=True, doc="""
@@ -691,7 +704,7 @@ class Widget(app.JsComponent):
         # Widgets that are custom classes containing a single layout propagate
         # that layout's limits
         if self.outernode.classList.contains('flx-Layout') is False:
-            if len(self.children) == 1:
+            if self.minsize_from_children is True and len(self.children) == 1:
                 child = self.children[0]
                 if child.outernode.classList.contains('flx-Layout') is True:
                     w3, w4, h3, h4 = child._query_min_max_size()

--- a/flexx/ui/layouts/_hv.py
+++ b/flexx/ui/layouts/_hv.py
@@ -293,7 +293,21 @@ class HVLayout(Layout):
         'left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'
         (insensitive to case and use of dashes).
         """)
-
+    
+    minsize_from_children = event.BoolProp(True, settable=True, doc="""
+        Whether the children are taken into account to calculate this
+        widget's size constraints. Default True: both the ``minsize``
+        of this widget and the size constraints of its children (plus
+        spacing and padding) are used to calculate the size constraints
+        for this widget.
+        
+        Set to False to prevent the content in this layout widget to
+        affect the parent's layout, e.g. to allow fully collapsing
+        *this* widget when the parent is a splitter. If this widget has
+        a lot of content, you may want to combine with
+        ``style='overflow-y: auto'``.
+        """)
+    
     spacing = event.FloatProp(4, settable=True, doc="""
         The space between two child elements (in pixels).
         """)
@@ -402,46 +416,57 @@ class HVLayout(Layout):
         # look for min/max sizes of their children. We could set min-width and
         # friends at the layout to help flexbox a bit, but that would possibly
         # overwrite a user-set value. Hopefully flexbox will get fixed soon.
-
-        # Collect contributions of child widgets
+        
         hori = 'h' in self.orientation
+        
+        # Own limits
+        mima0 = super()._query_min_max_size()
+        
+        # Init limits for children
         if hori is True:
             mima1 = [0, 0, 0, 1e9]
-            for child in self.children:
-                mima2 = child._size_limits
-                mima1[0] += mima2[0]
-                mima1[1] += mima2[1]
-                mima1[2] = max(mima1[2], mima2[2])
-                mima1[3] = min(mima1[3], mima2[3])
         else:
             mima1 = [0, 1e9, 0, 0]
+        
+        # Collect contributions of child widgets?
+        if self.minsize_from_children:
             for child in self.children:
                 mima2 = child._size_limits
-                mima1[0] = max(mima1[0], mima2[0])
-                mima1[1] = min(mima1[1], mima2[1])
-                mima1[2] += mima2[2]
-                mima1[3] += mima2[3]
-
-        # Dont forget padding and spacing
-        extra_padding = self.padding * 2
-        extra_spacing = self.spacing * (len(self.children) - 1)
-        for i in range(4):
-            mima1[i] += extra_padding
-        if hori is True:
-            mima1[0] += extra_spacing
-            mima1[1] += extra_spacing
-        else:
-            mima1[2] += extra_spacing
-            mima1[3] += extra_spacing
-
-        # Own limits
-        mima3 = super()._query_min_max_size()
-
+                if hori is True:
+                    mima1[0] += mima2[0]
+                    mima1[1] += mima2[1]
+                    mima1[2] = max(mima1[2], mima2[2])
+                    mima1[3] = min(mima1[3], mima2[3])
+                else:
+                    mima1[0] = max(mima1[0], mima2[0])
+                    mima1[1] = min(mima1[1], mima2[1])
+                    mima1[2] += mima2[2]
+                    mima1[3] += mima2[3]
+        
+        # Set unset max sizes
+        if mima1[1] == 0:
+            mima1[1] = 1e9
+        if mima1[3] == 0:
+            mima1[3] = 1e9
+        
+        # Add padding and spacing
+        if self.minsize_from_children:
+            extra_padding = self.padding * 2
+            extra_spacing = self.spacing * (len(self.children) - 1)
+            for i in range(4):
+                mima1[i] += extra_padding
+            if hori is True:
+                mima1[0] += extra_spacing
+                mima1[1] += extra_spacing
+            else:
+                mima1[2] += extra_spacing
+                mima1[3] += extra_spacing
+        
         # Combine own limits with limits of children
-        return [max(mima1[0], mima3[0]),
-                min(mima1[1], mima3[1]),
-                max(mima1[2], mima3[2]),
-                min(mima1[3], mima3[3])]
+        return [max(mima1[0], mima0[0]),
+                min(mima1[1], mima0[1]),
+                max(mima1[2], mima0[2]),
+                min(mima1[3], mima0[3])]
 
     @event.reaction('size', '_size_limits', mode='greedy')
     def __size_changed(self, *events):

--- a/flexx/ui/layouts/_hv.py
+++ b/flexx/ui/layouts/_hv.py
@@ -294,20 +294,6 @@ class HVLayout(Layout):
         (insensitive to case and use of dashes).
         """)
     
-    minsize_from_children = event.BoolProp(True, settable=True, doc="""
-        Whether the children are taken into account to calculate this
-        widget's size constraints. Default True: both the ``minsize``
-        of this widget and the size constraints of its children (plus
-        spacing and padding) are used to calculate the size constraints
-        for this widget.
-        
-        Set to False to prevent the content in this layout widget to
-        affect the parent's layout, e.g. to allow fully collapsing
-        *this* widget when the parent is a splitter. If this widget has
-        a lot of content, you may want to combine with
-        ``style='overflow-y: auto'``.
-        """)
-    
     spacing = event.FloatProp(4, settable=True, doc="""
         The space between two child elements (in pixels).
         """)


### PR DESCRIPTION
Use-case one: in a splitter widget, sometimes you just want to be able to collapse the content all the way.

Use-case two: if a widget inside a splitter widget has a lot of content, you sometimes don't want it to take the full space (and more) of the splitter. 

This adds a `minsize_from_children` property to the `Widget` class that can be set to False, so that only the intrinsic `minsize` of the widget is used to calculate its size constraints.