### PR TITLE
update bsdf Python implementation: implicit conversion of numpy scalars

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ exclude: test_*.py,exp/*,docs/*,build/*,dist/*,flexx/lui/*,python_sample*.py,
   flexx_legacy/*,_feedstock/*
 
 ignore: W291,W293,E123,E124,E126,E127,E203,E225,E226,E265,E301,E302,E303,E402,
-    E266,E731,E128,E306,E305,I,D,T,CG,N8
+    E266,E731,E128,E306,E305,I,D,T,CG,N8,S1
 
 max-line-length: 88
 


### PR DESCRIPTION
(this just copies over the latest bsdf_lite.py from the bsdf project)