### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,11 @@ recursive-include docs *
 prune docs/_build
 prune docs/ext/__pycache__
 
+recursive-include tasks *
+recursive-include flexx/app/tests *
+recursive-include flexx/event/tests *
+recursive-include flexx/util/tests *
+
 global-exclude .git*
 global-exclude *.pyo
 global-exclude *.pyc


### PR DESCRIPTION
Include the tests in the sdists.  This is particular important for Linux packagers.