### PR TITLE
Fix tests and get rid of some warnings

### DIFF
--- a/flexx/app/_app.py
+++ b/flexx/app/_app.py
@@ -227,8 +227,8 @@ class App:
 
         # Warn for PyComponents
         if issubclass(self.cls, PyComponent):
-            logger.warn('Exporting a PyComponent - any Python interactivity will '
-                        'not work in exported apps.')
+            logger.warning('Exporting a PyComponent - any Python interactivity will '
+                           'not work in exported apps.')
 
         d = {}
 
@@ -383,7 +383,7 @@ class AppManager(event.Component):
         if name in self._appinfo:
             old_app, pending, connected = self._appinfo[name]
             if app.cls is not old_app.cls:  # if app is not old_app:
-                logger.warn('Re-defining app class %r' % name)
+                logger.warning('Re-defining app class %r' % name)
         self._appinfo[name] = app, pending, connected
 
     def create_default_session(self, cls=None):
@@ -452,7 +452,7 @@ class AppManager(event.Component):
                     pending.remove(s)
                 count += len(to_remove)
             if count:
-                logger.warn('Cleared %i old pending sessions' % count)
+                logger.warning('Cleared %i old pending sessions' % count)
 
         except Exception as err:
             logger.error('Error when clearing old pending sessions: %s' % str(err))

--- a/flexx/app/_asset.py
+++ b/flexx/app/_asset.py
@@ -63,7 +63,7 @@ def solve_dependencies(things, warn_missing=False):
             for dep in thingmap[name].deps:
                 if dep not in names:
                     if warn_missing:
-                        logger.warn('%r has missing dependency %r' % (name, dep))
+                        logger.warning('%r has missing dependency %r' % (name, dep))
                 else:
                     j = names.index(dep)
                     if j > index:

--- a/flexx/app/_component2.py
+++ b/flexx/app/_component2.py
@@ -689,7 +689,7 @@ class BsdfComponentExtension(bsdf.Extension):
         else:
             c = session.get_component_instance(d['id'])
             if c is None:  # This should probably not happen
-                logger.warn('Using stub component for %s.' % d['id'])
+                logger.warning('Using stub component for %s.' % d['id'])
                 c = StubComponent(session, d['id'])
             else:
                 # Keep it alive for a bit
@@ -715,7 +715,7 @@ class BsdfComponentExtension(bsdf.Extension):
         else:
             c = session.get_component_instance(d['id'])
             if c is None:
-                logger.warn('Using stub component for %s.' % d['id'])
+                logger.warning('Using stub component for %s.' % d['id'])
                 c = StubComponent(session, d['id'])
         return c
 

--- a/flexx/app/_funcs.py
+++ b/flexx/app/_funcs.py
@@ -96,7 +96,7 @@ class NoteBookHelper:
 
     def capture(self):
         if self._real_ws is not None:
-            logger.warn('Notebookhelper already is in capture mode.')
+            logger.warning('Notebookhelper already is in capture mode.')
         else:
             if self._session._ws is None:
                 raise RuntimeError(

--- a/flexx/app/_modules.py
+++ b/flexx/app/_modules.py
@@ -282,7 +282,7 @@ class JSModule:
                 pass  # it may be a JS-global
             elif val is self._pymodule:
                 # Did not resolve first part of the name, so cannot be a JS global
-                logger.warn(msg)
+                logger.warning(msg)
             else:
                 raise RuntimeError(msg)  # E.g. typo in ui.Buttom
             return

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -44,7 +44,7 @@ def get_random_string(length=24, allowed_chars=None):
         srandom = random.SystemRandom()
     except NotImplementedError:  # pragma: no cover
         srandom = random
-        logger.warn('Falling back to less secure Mersenne Twister random string.')
+        logger.warning('Falling back to less secure Mersenne Twister random string.')
         bogus = "%s%s%s" % (random.getstate(), time.time(), 'sdkhfbsdkfbsdbhf')
         random.seed(hashlib.sha256(bogus.encode()).digest())
 
@@ -530,7 +530,7 @@ class Session:
             self._pending_commands.append(command)
         else:
             #raise RuntimeError('Cannot send commands; app is closed')
-            logger.warn('Cannot send commands; app is closed')
+            logger.warning('Cannot send commands; app is closed')
 
     def _receive_command(self, command):
         """ Received a command from JS.
@@ -543,7 +543,7 @@ class Session:
         elif cmd == 'INFO':
             logger.info('JS: ' + command[1])
         elif cmd == 'WARN':
-            logger.warn('JS: ' + command[1])
+            logger.warning('JS: ' + command[1])
         elif cmd == 'ERROR':
             logger.error('JS: ' + command[1] +
                          ' - stack trace in browser console (hit F12).')
@@ -553,7 +553,7 @@ class Session:
             if ob is None:
                 if id not in self._dead_component_ids:
                     t = 'Cannot invoke %s.%s; session does not know it (anymore).'
-                    logger.warn(t % (id, name))
+                    logger.warning(t % (id, name))
             elif ob._disposed:
                 pass  # JS probably send something before knowing the object was dead
             else:

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -591,7 +591,7 @@ class WSHandler(WebSocketHandler):
             elif time.time() - self._pongtime > dt:
                 # Delay is so big that connection probably dropped.
                 # Note that a browser sends a pong even if JS is busy
-                logger.warn('Closing connection due to lack of pong')
+                logger.warning('Closing connection due to lack of pong')
                 self.close(1000, 'Conection timed out (no pong).')
                 return
 
@@ -645,5 +645,5 @@ class WSHandler(WebSocketHandler):
         elif connecting_host in config.host_whitelist:
             return True
         else:
-            logger.warn('Connection refused from %s' % origin)
+            logger.warning('Connection refused from %s' % origin)
             return False

--- a/flexx/app/bsdf_lite.py
+++ b/flexx/app/bsdf_lite.py
@@ -129,8 +129,8 @@ class BsdfLiteSerializer(object):
             raise NameError('Extension names must be nonempty and shorter '
                             'than 251 chars.')
         if name in self._extensions:
-            logger.warn('BSDF warning: overwriting extension "%s", '
-                        'consider removing first' % name)
+            logger.warning('BSDF warning: overwriting extension "%s", '
+                           'consider removing first' % name)
 
         # Get classes
         cls = extension.cls
@@ -386,7 +386,7 @@ class BsdfLiteSerializer(object):
             if extension is not None:
                 value = extension.decode(self, value)
             else:
-                logger.warn('BSDF warning: no extension found for %r' % ext_id)
+                logger.warning('BSDF warning: no extension found for %r' % ext_id)
 
         return value
 
@@ -429,7 +429,7 @@ class BsdfLiteSerializer(object):
         if minor_version > VERSION[1]:  # minor should be < ours
             t = ('BSDF warning: reading file with higher minor version (%s) '
                  'than the implementation (%s).')
-            logger.warn(t % (file_version, __version__))
+            logger.warning(t % (file_version, __version__))
 
         return self._decode(f)
 

--- a/flexx/event/_action.py
+++ b/flexx/event/_action.py
@@ -153,8 +153,8 @@ class Action:
             if ob is not None:
                 res = func(ob, *args)
                 if res is not None:
-                    logger.warn('Action (%s) is not supposed to return a value' %
-                                self._name)
+                    logger.warning('Action (%s) is not supposed to return a value' %
+                                   self._name)
         else:
             loop.add_action_invokation(self, args)
 

--- a/flexx/event/_action.py
+++ b/flexx/event/_action.py
@@ -153,7 +153,7 @@ class Action:
             if ob is not None:
                 res = func(ob, *args)
                 if res is not None:
-                    logger.warning('Action (%s) is not supposed to return a value' %
+                    logger.warning('Action (%s) should not return a value' %
                                    self._name)
         else:
             loop.add_action_invokation(self, args)

--- a/flexx/event/_component.py
+++ b/flexx/event/_component.py
@@ -388,12 +388,12 @@ class Component(with_metaclass(ComponentMeta, object)):
                 pass
             elif type.startswith('mouse_'):
                 t = 'The event "{}" has been renamed to "pointer{}".'
-                logger.warn(t.format(type, type[5:]))
+                logger.warning(t.format(type, type[5:]))
             else:  # ! means force
                 msg = ('Event type "{type}" does not exist on component {id}. ' +
                        'Use "!{type}" or "!xx.yy.{type}" to suppress this warning.')
                 msg = msg.replace('{type}', type).replace('{id}', self._id)
-                logger.warn(msg)
+                logger.warning(msg)
 
         # Insert reaction in good place (if not already in there) - sort as we add
         comp1 = label + '-' + reaction._id

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -89,9 +89,10 @@ $Logger.debug = function (msg) {
 $Logger.info = function (msg) {
     if (this.level <= 20) { console.info(msg); }
 };
-$Logger.warn = function (msg) {
+$Logger.warning = function (msg) {
     if (this.level <= 30) { console.warn(msg); }
 };
+$Logger.warn = $Logger.warning;
 $Logger.exception = function (msg) {
     console.error(msg);
 };
@@ -269,7 +270,7 @@ class ComponentJS:  # pragma: no cover
             if loop.can_mutate(self) is True:
                 res = action_func.apply(self, arguments)
                 if res is not None:
-                    logger.warn('Action (%s) is not supposed to return a value' % name)
+                    logger.warning('Action (%s) should not return a value' % name)
             else:
                 loop.add_action_invokation(action, arguments)
             return self

--- a/flexx/event/_loop.py
+++ b/flexx/event/_loop.py
@@ -463,7 +463,7 @@ class Loop:
     #                 try:
     #                     callback(*args)
     #                 except Exception as why:
-    #                     logger.warn('callback failed: {}:\n{}'.format(callback, why))
+    #                     logger.warning('blck failed: {}:\n{}'.format(callback, why))
     #
     #         def postEventWithCallback(self, callback, *args):
     #             self.queue.put((callback, args))

--- a/flexx/event/_reaction.py
+++ b/flexx/event/_reaction.py
@@ -23,7 +23,7 @@ def looks_like_method(func):
     if hasattr(func, '__func__'):
         return False  # this is a bound method
     try:
-        return inspect.getargspec(func)[0][0] in ('self', 'this')
+        return list(inspect.signature(func).parameters)[0] in ('self', 'this')
     except (TypeError, IndexError):
         return False
 

--- a/flexx/event/_reaction.py
+++ b/flexx/event/_reaction.py
@@ -24,7 +24,7 @@ def looks_like_method(func):
         return False  # this is a bound method
     try:
         return list(inspect.signature(func).parameters)[0] in ('self', 'this')
-    except (TypeError, IndexError):
+    except (TypeError, IndexError, ValueError):
         return False
 
 

--- a/flexx/event/tests/test_actions.py
+++ b/flexx/event/tests/test_actions.py
@@ -44,7 +44,7 @@ def test_action_simple():
     43
     43
     12
-    ? not supposed to return a value
+    ? should not return a value
     """
 
     m = MyObject()

--- a/flexx/util/config.py
+++ b/flexx/util/config.py
@@ -300,8 +300,8 @@ class Config(object):
             try:
                 text = open(filename, 'rb').read().decode()
             except Exception as err:
-                logging.warn('Could not read config from %r:\n%s' %
-                             (filename, str(err)))
+                logging.warning('Could not read config from %r:\n%s' %
+                                (filename, str(err)))
                 return
             self.load_from_string(text, filename)
 
@@ -313,7 +313,7 @@ class Config(object):
         try:
             self._load_from_string(text, filename)
         except Exception as err:
-            logging.warn(str(err))
+            logging.warning(str(err))
 
     def _load_from_string(self, s, filename):
         # Create default section, so that users can work with sectionless

--- a/flexx/util/tests/test_logging.py
+++ b/flexx/util/tests/test_logging.py
@@ -31,7 +31,7 @@ def test_set_log_level():
 def test_capture():
 
     with capture_log('info') as log:
-        logger.warn('AA')
+        logger.warning('AA')
         logger.info('BB')
 
     msg1 = log[0]


### PR DESCRIPTION
* Stop using deprecated `inspect.getargspec()`
* Stop using deprecated `logger.warn()`
