### PR TITLE
Adds test (and comment) on 'Serving apps at' ready signal

### DIFF
--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -126,6 +126,7 @@ class TornadoServer(AbstractServer):
         proto = 'http'
         if 'ssl_options' in kwargs:
             proto = 'https'
+        # This string 'Serving apps at' is our 'ready' signal and is tested for.
         logger.info('Serving apps at %s://%s:%i/' % (proto, host, port))
 
     def _close(self):

--- a/flexx/app/tests/test_funcs.py
+++ b/flexx/app/tests/test_funcs.py
@@ -356,6 +356,6 @@ def test_serving_apps_at_output_message():
         app.stop()  # triggers event to stop
         app.start()
 
-    assert "Serving apps at" in ''.join(log)
+    assert 'Serving apps at' in ''.join(log)
 
 run_tests_if_main()

--- a/flexx/app/tests/test_funcs.py
+++ b/flexx/app/tests/test_funcs.py
@@ -1,4 +1,5 @@
 from flexx.util.testing import run_tests_if_main, raises
+from flexx.util.logging import capture_log
 
 import time
 import asyncio
@@ -346,5 +347,15 @@ def test_flexx_multiprocessing():
 
     assert True  # Just arriving here is enough to pass this test
 
+
+def test_serving_apps_at_output_message():
+    """ Test for 'Serving apps at' ready signal.
+    """
+    with capture_log('info') as log:
+        server = app.create_server()
+        app.stop()  # triggers event to stop
+        app.start()
+
+    assert "Serving apps at" in ''.join(log)
 
 run_tests_if_main()


### PR DESCRIPTION
Here's a start. I guess checking for a url could be done, but that would have to be part of the "spec" then I guess.