### PR TITLE
Update _filebrowser.py

### DIFF
--- a/flexx/ui/pywidgets/_filebrowser.py
+++ b/flexx/ui/pywidgets/_filebrowser.py
@@ -165,7 +165,7 @@ class FileBrowserWidget(PyWidget):
         dirname = events[-1].dirname
         filename = events[-1].filename
         print(dirname, filename)
-        if dirname:
+        if dirname is not None and os.path.isdir(dirname):
             self.set_path(dirname)
         elif filename:
             self.selected(filename)

--- a/flexx/ui/pywidgets/_filebrowser.py
+++ b/flexx/ui/pywidgets/_filebrowser.py
@@ -78,10 +78,10 @@ class _FileBrowserJS(Widget):
             elements.append(create_element("span", {}, " ❑■"[kind] or ""))
             if kind == 1:
                 elements.append(create_element("u",
-                    {"dirname": dirname + sep + fname}, fname))
+                    {"dirname": dirname + sep + fname, "filename": None}, fname))
             else:
                 elements.append(create_element("u",
-                    {"filename": dirname + sep + fname}, fname))
+                    {"filename": dirname + sep + fname, "dirname": None}, fname))
             if size >= 1048576:
                 elements.append(create_element("i", {},
                     "{:0.1f} MiB".format(size/1048576)))
@@ -165,7 +165,7 @@ class FileBrowserWidget(PyWidget):
         dirname = events[-1].dirname
         filename = events[-1].filename
         print(dirname, filename)
-        if dirname is not None and os.path.isdir(dirname):
+        if dirname:
             self.set_path(dirname)
         elif filename:
             self.selected(filename)


### PR DESCRIPTION
If there are no subdirectories in the current viewed path, clicking on the top file does nothing, as the emitted directory is not `None` but is invalid (it's an invalid value: **path + "/" + name_of_last_directory**).
This is a quick fix for this issue.

I do not have enough experience to know how to change that the first file emits `"directory": None` (like the other files do), but if it's simple then tell me and I'll update the code.
