### PR TITLE
Allow colon passed to apply_style()

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -595,7 +595,7 @@ class Widget(app.JsComponent):
         if style:
             for part in style.split(';'):
                 if ':' in part:
-                    key, val = part.split(':')
+                    key, val = part.split(':', 1)
                     key, val = key.trim(), val.trim()
                     self.outernode.style[key] = val
                     d[key] = val


### PR DESCRIPTION
Because of the CSS parsing, apply_style() would split on any colon which would split http:// links. With this small change it will only split on the first colon and then on the next semicolon for a next line of css