### PR TITLE
Issue when validating the existance of an asset when the asset is a link

### DIFF
--- a/flexx/app/_assetstore.py
+++ b/flexx/app/_assetstore.py
@@ -391,8 +391,9 @@ class AssetStore:
             str: the (relative) url at which the asset can be retrieved.
         """
         # Get or create asset
-        if asset_name in self._assets:
-            asset = self._assets[asset_name]
+        name = asset_name.replace('\\', '/').split('/')[-1]
+        if name in self._assets:
+            asset = self._assets[name]
             if source is not None:
                 t = 'associate_asset() for %s got source, but asset %r already exists.'
                 raise TypeError(t % (mod_name, asset_name))


### PR DESCRIPTION
I add an issue when using `flx.assets.associate_asset(__name__, 'https://cdn.plot.ly/plotly-latest.min.js')` in my __main__ module. Turns out the asset store was not detecting the name in it's list of loaded assests as the name in the dict is shorten to the filename.

I applied correction an now submitting. 

Thanks,