### PR TITLE
fix deprecated lib call

### DIFF
--- a/flexx/app/_app.py
+++ b/flexx/app/_app.py
@@ -8,7 +8,7 @@ import sys
 import time
 import weakref
 import zipfile
-from base64 import encodestring as encodebytes
+from base64 import encodebytes
 
 import webruntime
 


### PR DESCRIPTION
encodestring is deprecated since 3.1,
was still available until 3.8,
gone in 3.9
encodebytes since 3.1, too