### PR TITLE
Symmetry betwee PyWidget and Widget

### DIFF
--- a/flexx/app/_component2.py
+++ b/flexx/app/_component2.py
@@ -353,7 +353,9 @@ class LocalComponent(BaseAppComponent):
         # This is a good time to register with the session, and
         # instantiate the proxy class. Property values have been set at this
         # point, but init() has not yet been called.
-
+        # Property values must be poped when consumed so that the remainer is used for 
+        # instantiation of the Widget
+        
         # Keep track of what events are registered at the proxy
         self.__event_types_at_proxy = []
 

--- a/flexx/app/_flaskserver.py
+++ b/flexx/app/_flaskserver.py
@@ -158,7 +158,7 @@ class FlaskServer(AbstractServer):
         """
         while True:
             time.sleep(0)
-            await asyncio.sleep(0)
+            await asyncio.sleep(1e-9) # any number above 0 will keep low CPU usage 
 
     def start(self):
         # Register blueprints for all apps:

--- a/flexx/event/_component.py
+++ b/flexx/event/_component.py
@@ -206,6 +206,8 @@ class Component(with_metaclass(ComponentMeta, object)):
         # With self as the active component (and thus mutable), init the
         # values of all properties, and apply user-defined initialization
         with self:
+            # This call will pop some of the consumed property values
+            # will remain properties used for the DOM component initialisation
             self._comp_init_property_values(property_values)
             self.init(*init_args)
 
@@ -218,9 +220,9 @@ class Component(with_metaclass(ComponentMeta, object)):
     def _comp_init_property_values(self, property_values):
         """ Initialize property values, combining given kwargs (in order)
         and default values.
+        Property values are popped when consumed so that the remainer is used for 
+        other initialisations without mixup.
         """
-        # Property values must be poped when consumed so that the remainer is used for 
-        # instantiation of the Widget
         values = []
         # First collect default property values (they come first)
         for name in self.__properties__:  # is sorted by name

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -1158,7 +1158,9 @@ class PyWidget(app.PyComponent):
         # when this is the active component, and after the original
         # version of this has been called, everything related to session
         # etc. will work fine.
-
+        # Property values must be poped when consumed so that the remainer is used for 
+        # instantiation of the Widget
+        
         # First extract the kwargs
         kwargs_for_real_widget = {}
         for name in list(property_values.keys()):
@@ -1168,7 +1170,7 @@ class PyWidget(app.PyComponent):
         # Call original version, sets _session, amongst other things
         super()._comp_init_property_values(property_values)
         # Create widget and activate it
-        w = self._WidgetCls(**kwargs_for_real_widget)
+        w = self._WidgetCls(**kwargs_for_real_widget, **property_values)
         self.__exit__(None, None, None)
         self._jswidget = w
         self.__enter__()

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -1158,8 +1158,8 @@ class PyWidget(app.PyComponent):
         # when this is the active component, and after the original
         # version of this has been called, everything related to session
         # etc. will work fine.
-        # Property values must be poped when consumed so that the remainer is used for 
-        # instantiation of the Widget
+        # Property values are poped when consumed so that the remainer is used for 
+        # instantiation of the js Widget
         
         # First extract the kwargs
         kwargs_for_real_widget = {}
@@ -1168,8 +1168,11 @@ class PyWidget(app.PyComponent):
                 if name in self._WidgetCls.__properties__:
                     kwargs_for_real_widget[name] = property_values.pop(name)
         # Call original version, sets _session, amongst other things
+        # it also pops the consumed property values so the remainer
+        # can be used to initialize the js _WidgetCls
         super()._comp_init_property_values(property_values)
-        # Create widget and activate it
+        # Create widget and activate it - at this point, all property values
+        # should be intended for the js Widget.
         w = self._WidgetCls(**kwargs_for_real_widget, **property_values)
         self.__exit__(None, None, None)
         self._jswidget = w

--- a/flexxamples/howtos/bokehdemo.py
+++ b/flexxamples/howtos/bokehdemo.py
@@ -35,7 +35,7 @@ class BokehExample(flx.PyComponent):
             self.plot1 = flx.BokehWidget.from_plot(p1, title='Scatter')
             with flx.VFix(title='Sine'):
                 Controls()
-                with flx.Widget(style='overflow-y:auto;', flex=1):
+                with flx.PyWidget(style='overflow-y:auto;', flex=1):
                     self.plot2 = flx.BokehWidget.from_plot(p2)
                     self.plot3 = flx.BokehWidget.from_plot(p3)
 


### PR DESCRIPTION
Hi almarklein, I would like to push a change to have more symmetry between PyWidget and Widget:
I can do:
```
    with ui.Widget(style=overlay_style+"width:0%;") as self.waiting_overlay:
        (...)
```
But could not do:
```
    with ui.PyWidget(style=overlay_style+"width:0%;") as self.waiting_overlay:
        (...)
```
Which I found anoying as I'm using server side processing quite a lot and need to switch Widget from one side to the other seamlessly. 

I changed the `bokehdemo.py` and inserted a PyWidget within to show the style in action.

I have a lot of other things relying on this change so I hope it goes forward one way or another. I hope to submit them at a later point when they get more reliable.

P.S. there is also an optimisation for flask serving within the code (in _flaskserver.py).

Thank you for your time.