### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/guide/widget_basics.rst
+++ b/docs/guide/widget_basics.rst
@@ -170,7 +170,7 @@ worry, you don't need it:
 
 The ``_render_dom()`` method is called from an implicit reaction. This means
 that when any properties that are accessed during this function change,
-the function is automatically called again. This thus provides a declerative
+the function is automatically called again. This thus provides a declarative
 way to define the appearance of a widget using HTML elements.
 
 Above, the third argument in ``create_element()`` is a string, but this may

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -448,7 +448,7 @@ class Session:
 
     def _register_module(self, mod_name):
         """ Register a module with the client, as well as its
-        dependencies, and associated assests of the module and its
+        dependencies, and associated assets of the module and its
         dependencies. If the module was already defined, it is
         re-defined.
         """
@@ -607,7 +607,7 @@ class Session:
     def keep_alive(self, ob, iters=1):
         """ Keep an object alive for a certain amount of time, expressed
         in Python-JS ping roundtrips. This is intended for making JsComponent
-        (i.e. proxy components) survice the time between instantiation
+        (i.e. proxy components) service the time between instantiation
         triggered from JS and their attachement to a property, though any type
         of object can be given.
         """

--- a/flexx/app/tests/test_asset.py
+++ b/flexx/app/tests/test_asset.py
@@ -212,7 +212,7 @@ def test_bundle():
     # Modules are sorted
     assert bundle.modules == (m3, m1, m2)
 
-    # Deps are agregated
+    # Deps are aggregated
     assert 'flexx.app.js' in bundle.deps
     assert 'flexx.app._component2.js' in bundle.deps
     assert not any('flexx.ui' in dep for dep in bundle.deps)

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -182,7 +182,7 @@ class ComponentJS:  # pragma: no cover
             if name not in property_values:
                 values.append((name, self['_' + name + '_value']))
         # Then collect user-provided values
-        for name, value in property_values.items():  # is sorted by occurance in py36
+        for name, value in property_values.items():  # is sorted by occurrence in py36
             if name not in self.__properties__:
                 if name in self.__attributes__:
                     raise AttributeError('%s.%s is an attribute, not a property' %

--- a/flexx/event/_reaction.py
+++ b/flexx/event/_reaction.py
@@ -269,7 +269,7 @@ class Reaction:
         * 'greedy': this reaction receives all its events (since the last event
           loop iteration) in a single call (even if this breaks the order of
           events with respect to other reactions). Use this when multiple related
-          events must be handled simultenously (e.g. when syncing properties).
+          events must be handled simultaneously (e.g. when syncing properties).
         * 'auto': this reaction tracks what properties it uses, and is
           automatically triggered when any of these properties changes. Like
           'greedy' there is at most one call per event loop iteration.

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -766,7 +766,7 @@ class Widget(app.JsComponent):
     @event.action
     def set_parent(self, parent, pos=None):
         """ Set the parent widget (can be None). This action also mutates the
-        childen of the old and new parent.
+        children of the old and new parent.
         """
         old_parent = self.parent  # or None
         new_parent = parent
@@ -883,7 +883,7 @@ class Widget(app.JsComponent):
                 self._capture_flag = 2
                 window.document.addEventListener("mousemove", mmove_outside, True)
                 window.document.addEventListener("mouseup", mup_outside, True)
-                # Explicit caputuring is not necessary, and even causes problems on IE
+                # Explicit capturing is not necessary, and even causes problems on IE
                 #if self.node.setCapture:
                 #    self.node.setCapture()
 

--- a/flexx/util/tests/test_config.py
+++ b/flexx/util/tests/test_config.py
@@ -246,8 +246,8 @@ def test_read_file_later():
 
     c.load_from_file(filename2)
     assert c.bar == 4  # from filename2
-    assert c.eggs == 'haha'  # from what we set - takes precedense
-    assert c.spam == 10  # from what we set - precedense over env var
+    assert c.eggs == 'haha'  # from what we set - takes precedence
+    assert c.spam == 10  # from what we set - precedence over env var
 
 
 def test_access():

--- a/flexxamples/howtos/echarts_example.py
+++ b/flexxamples/howtos/echarts_example.py
@@ -6,7 +6,7 @@ Example demonstrating how to integrate famous eChart into flexx.
 
 from flexx import flx
 
-# # use local assests, I download the echarts.min.js and put in local folder
+# # use local assets, I download the echarts.min.js and put in local folder
 # import os
 #
 # BASE_DIR = os.getcwd()

--- a/flexxamples/testers/tricky_events.py
+++ b/flexxamples/testers/tricky_events.py
@@ -51,7 +51,7 @@ class SyncedSlidersRight(SyncedSlidersBase):
     single reaction, which is marked as greedy. This ensures that all events
     to either of the sliders get handled in a single call to the reaction,
     which avoids a ping-pong effect. Only having a single (normal) reaction
-    reduced the chance of a ping-pong effect, but does not elliminate it.
+    reduced the chance of a ping-pong effect, but does not eliminate it.
 
     Even better would be to react to ``user_value``  or ``user_done``
     to avoid ping-ping altogether.


### PR DESCRIPTION
There are small typos in:
- docs/guide/widget_basics.rst
- flexx/app/_session.py
- flexx/app/tests/test_asset.py
- flexx/event/_js.py
- flexx/event/_reaction.py
- flexx/ui/_widget.py
- flexx/util/tests/test_config.py
- flexxamples/howtos/echarts_example.py
- flexxamples/testers/tricky_events.py

Fixes:
- Should read `precedence` rather than `precedense`.
- Should read `assets` rather than `assests`.
- Should read `simultaneously` rather than `simultenously`.
- Should read `service` rather than `survice`.
- Should read `occurrence` rather than `occurance`.
- Should read `eliminate` rather than `elliminate`.
- Should read `declarative` rather than `declerative`.
- Should read `children` rather than `childen`.
- Should read `capturing` rather than `caputuring`.
- Should read `aggregated` rather than `agregated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md